### PR TITLE
Oscar chumpitaz: Solución bug de citar post, botón de emoji siempre visible en web

### DIFF
--- a/__tests__/lib/compose.test.ts
+++ b/__tests__/lib/compose.test.ts
@@ -1,0 +1,57 @@
+// Define la función onNewLink con las dependencias simuladas
+const onNewLink = (
+  uri: string,
+  quote: boolean | undefined,
+  extLink: {uri: string; isLoading: boolean} | null,
+  setExtLink: (
+    value: React.SetStateAction<{uri: string; isLoading: boolean} | null>,
+  ) => void,
+) => {
+  if (quote) return
+  if (extLink != null) return
+  setExtLink({uri, isLoading: true})
+}
+
+// Describe las pruebas para onNewLink
+describe('onNewLink', () => {
+  test('debería llamar a setExtLink con uri y isLoading true cuando quote es falso y extLink es nulo', () => {
+    // Simula una función mock para setExtLink
+    const mockSetExtLink = jest.fn()
+
+    // Llama a la función con los parámetros simulados
+    onNewLink('https://example.com', undefined, null, mockSetExtLink)
+
+    // Verifica si setExtLink fue llamado con los argumentos esperados
+    expect(mockSetExtLink).toHaveBeenCalledWith({
+      uri: 'https://example.com',
+      isLoading: true,
+    })
+  })
+
+  test('no debería llamar a setExtLink cuando quote es verdadero', () => {
+    // Simula una función mock para setExtLink
+    const mockSetExtLink = jest.fn()
+
+    // Llama a la función con quote como verdadero
+    onNewLink('https://example.com', true, null, mockSetExtLink)
+
+    // Verifica que setExtLink no fue llamado
+    expect(mockSetExtLink).not.toHaveBeenCalled()
+  })
+
+  test('no debería llamar a setExtLink cuando extLink no es nulo', () => {
+    // Simula una función mock para setExtLink
+    const mockSetExtLink = jest.fn()
+
+    // Llama a la función con extLink no nulo
+    onNewLink(
+      'https://example.com',
+      undefined,
+      {uri: 'https://previouslink.com', isLoading: false},
+      mockSetExtLink,
+    )
+
+    // Verifica que setExtLink no fue llamado
+    expect(mockSetExtLink).not.toHaveBeenCalled()
+  })
+})

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -224,10 +224,11 @@ export const ComposePost = observer(function ComposePost({
 
   const onNewLink = useCallback(
     (uri: string) => {
+      if (quote) return
       if (extLink != null) return
       setExtLink({uri, isLoading: true})
     },
-    [extLink, setExtLink],
+    [quote, extLink, setExtLink],
   )
 
   const onPhotoPasted = useCallback(

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -116,7 +116,7 @@ export const ComposePost = observer(function ComposePost({
   const {closeComposer} = useComposerControls()
   const {track} = useAnalytics()
   const pal = usePalette('default')
-  const {isTabletOrDesktop, isMobile} = useWebMediaQueries()
+  const {isTabletOrDesktop} = useWebMediaQueries()
   const {_} = useLingui()
   const requireAltTextEnabled = useRequireAltTextEnabled()
   const langPrefs = useLanguagePrefs()
@@ -592,7 +592,7 @@ export const ComposePost = observer(function ComposePost({
               onSelectGif={onSelectGif}
               disabled={hasMedia}
             />
-            {!isMobile ? (
+            {isWeb && (
               <Button
                 onPress={onEmojiButtonPress}
                 style={a.p_sm}
@@ -603,7 +603,7 @@ export const ComposePost = observer(function ComposePost({
                 color="primary">
                 <EmojiSmile size="lg" />
               </Button>
-            ) : null}
+            )}
           </View>
           <View style={a.flex_1} />
           <SelectLangBtn />


### PR DESCRIPTION
- Citar Publicación: se realizó el cambio para replicar el comportamiento al del aplicativo X. Para ello se modificó “onNewLink” del archivo “Composer.tsx” añadiendo una validación adicional la cual verifica si el posteo refiere a la cita de una publicació, si ese fuera el caso, cualquier otro link que se añada a la cita no reemplazará al post citado.
- Botón de emoji: se realizó el ajuste que permite que el botón de emoji permanezca sin importar el tamaño del ancho del navegador cuando la plataforma es web. Para ello se modificó el componente “Button” de los emoji se reemplazó la condición existente por una que valide la plataforma actual usando los métodos ya existente en el aplicativo.
